### PR TITLE
Add pyproject.toml template

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ redirect support questions to our community forum.
 
 The .pylintrc is the configuration for [Pylint](https://www.pylint.org/) which is used to test the code quality of our python projects.
 
+## pyproject.toml
+
+The `pyproject.toml` template provides a consistent specification of the minimum
+build system requirements for Python projects. The file format is specified in
+[PEP518](https://www.python.org/dev/peps/pep-0518/).
+
+The template contains configuration options for the
+[autohooks](https://github.com/bjoernricks/autohooks) framework and for the
+[black](https://github.com/ambv/black) code formatter. Together, this
+configuration makes sure that all commits are properly formatted in a consistent
+style.
+
+Note that both `autohooks` and `black` need to be present in the development
+environment for the configuration to be applied.
+
 ## License
 
 Copyright (C) 2018 [Greenbone Networks GmbH](https://www.greenbone.net/)

--- a/pyproject-template.toml
+++ b/pyproject-template.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+
+[tool.black]
+line-length = 80
+py36 = false
+skip-string-normalization = true
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.venv
+  | \.circleci
+  | \.github
+  | \.vscode
+  | _build
+  | build
+  | dist
+  | docs
+)/
+'''
+
+[tool.autohooks]
+pre-commit = ['autohooks.plugins.black']


### PR DESCRIPTION
Add a template for the `pyproject.toml` file for Python projects, with
configuration for `black` and `autohooks` and explains the file in the
`README.md`.