### PR TITLE
Adjust target versions in black config

### DIFF
--- a/pyproject-template.toml
+++ b/pyproject-template.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 80
-py36 = false
+target-version = ['py35', 'py36', 'py37', 'py38']
 skip-string-normalization = true
 exclude = '''
 /(


### PR DESCRIPTION
New projects or projects updating to `black` version 19.10b0 should use
the `target-version` configuration variable instead of the deprecated
`py36` etc. setting.